### PR TITLE
Make markers immutable

### DIFF
--- a/src/main/java/com/atomicjar/logging/LogFmtMarker.java
+++ b/src/main/java/com/atomicjar/logging/LogFmtMarker.java
@@ -2,8 +2,9 @@ package com.atomicjar.logging;
 
 import org.slf4j.Marker;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
@@ -23,23 +24,25 @@ import java.util.function.BiConsumer;
  */
 public class LogFmtMarker implements Marker {
 
-    private final Map<String, Object> data = new LinkedHashMap<>();
+    private final Map<String, Object> data;
 
-    private LogFmtMarker(String key, Object value) {
-        data.put(key, value);
+    private LogFmtMarker(Map<String, Object> data) {
+        this.data = Collections.unmodifiableMap(data);
     }
 
+
     public static LogFmtMarker with(String key, Object value) {
-        return new LogFmtMarker(key, value);
+        return new LogFmtMarker(Map.of(key, value));
     }
 
     public LogFmtMarker and(String key, Object value) {
+        var copy = new HashMap<>(data);
         if (value != null) {
-            data.put(key, value);
+            copy.put(key, value);
         } else {
-            data.remove(key);
+            copy.remove(key);
         }
-        return this;
+        return new LogFmtMarker(copy);
     }
 
     void forEachData(BiConsumer<String, Object> consumer) {

--- a/src/test/java/com/atomicjar/logging/LogFmtMarkerTest.java
+++ b/src/test/java/com/atomicjar/logging/LogFmtMarkerTest.java
@@ -2,11 +2,13 @@ package com.atomicjar.logging;
 
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class LogFmtMarkerTest {
     @Test
     public void testImmutability() {
         var orig = LogFmtMarker.with("a", "b");
         orig.and("c", "d");
-        assert orig.getData().size() == 1;
+        assertThat(orig.getData()).hasSize(1);
     }
 }

--- a/src/test/java/com/atomicjar/logging/LogFmtMarkerTest.java
+++ b/src/test/java/com/atomicjar/logging/LogFmtMarkerTest.java
@@ -1,0 +1,12 @@
+package com.atomicjar.logging;
+
+import org.junit.jupiter.api.Test;
+
+public class LogFmtMarkerTest {
+    @Test
+    public void testImmutability() {
+        var orig = LogFmtMarker.with("a", "b");
+        orig.and("c", "d");
+        assert orig.getData().size() == 1;
+    }
+}


### PR DESCRIPTION
We figured for a couple of reasons the log format marker should be immutable:
* it seems to be what people expect
* re-using a base-marker to create sub-markers is not possible when the same mutable object is re-used
* there's probably more