### PR TITLE
Allow `null` values in `with()`

### DIFF
--- a/src/main/java/com/atomicjar/logging/LogFmtMarker.java
+++ b/src/main/java/com/atomicjar/logging/LogFmtMarker.java
@@ -32,8 +32,7 @@ public class LogFmtMarker implements Marker {
 
 
     public static LogFmtMarker with(String key, Object value) {
-        var marker = new LogFmtMarker(Collections.emptyMap());
-        return value == null ? marker : marker.and(key, value);
+        return new LogFmtMarker(value == null ? Collections.emptyMap() : Map.of(key, value));
     }
 
     public LogFmtMarker and(String key, Object value) {

--- a/src/main/java/com/atomicjar/logging/LogFmtMarker.java
+++ b/src/main/java/com/atomicjar/logging/LogFmtMarker.java
@@ -32,7 +32,8 @@ public class LogFmtMarker implements Marker {
 
 
     public static LogFmtMarker with(String key, Object value) {
-        return new LogFmtMarker(Collections.emptyMap()).and(key, value);
+        var marker = new LogFmtMarker(Collections.emptyMap());
+        return value == null ? marker : marker.and(key, value);
     }
 
     public LogFmtMarker and(String key, Object value) {

--- a/src/main/java/com/atomicjar/logging/LogFmtMarker.java
+++ b/src/main/java/com/atomicjar/logging/LogFmtMarker.java
@@ -26,13 +26,13 @@ public class LogFmtMarker implements Marker {
 
     private final Map<String, Object> data;
 
-    private LogFmtMarker(Map<String, Object> data) {
-        this.data = Collections.unmodifiableMap(data);
+    private LogFmtMarker(Map<String,Object> data) {
+        this.data = data;
     }
 
 
     public static LogFmtMarker with(String key, Object value) {
-        return new LogFmtMarker(Map.of(key, value));
+        return new LogFmtMarker(Collections.emptyMap()).and(key, value);
     }
 
     public LogFmtMarker and(String key, Object value) {

--- a/src/test/java/com/atomicjar/logging/LogFmtMarkerTest.java
+++ b/src/test/java/com/atomicjar/logging/LogFmtMarkerTest.java
@@ -11,4 +11,14 @@ public class LogFmtMarkerTest {
         orig.and("c", "d");
         assertThat(orig.getData()).hasSize(1);
     }
+
+    @Test
+    public void testWithNullValues() {
+        LogFmtMarker.with("a", null);
+    }
+
+    @Test
+    public void testAndNullValues() {
+        LogFmtMarker.with("a", "b").and("c", null);
+    }
 }


### PR DESCRIPTION
This used to work before and works with `and()`, so IMO it should also work with `with()`.